### PR TITLE
Add real qp to manager

### DIFF
--- a/MWFTP/manager.py
+++ b/MWFTP/manager.py
@@ -37,17 +37,17 @@ def run(job_iterator: Iterable[JobInfo], data_iterator: Callable,
     sethandlers()
     if qp_kwargs is None:
         qp_kwargs = {}
-    qp_defaults = {'jobname': 'manager'}
 
     qprovider = qp if not use_fakeqp else fakeqp
 
-    with qprovider(**{**qp_defaults, **qp_kwargs}) as q:
+    with qprovider(**qp_kwargs) as q:
         q.startpermanentrun()
 
         tkttores = []
         for job_info in job_iterator:
             tkttores.append(q.method(_run_per_job, (job_info, data_iterator, xy_function,
-                                                    output_dir)))
+                                                    output_dir),
+                                     _job_name=job_info.name))
 
         fnames = []
         for r in tkttores:

--- a/MWFTP/manager.py
+++ b/MWFTP/manager.py
@@ -3,7 +3,7 @@ import os
 from typing import Iterable, Callable, Dict, NamedTuple, Any
 
 import pandas as pd
-from LabQueue.qp import fakeqp
+from LabQueue.qp import fakeqp, qp
 from LabUtils.addloglevels import sethandlers
 
 
@@ -30,22 +30,24 @@ def _run_per_job(job_info: JobInfo, data_iterator_gen: Callable, xy_function: Ca
     return output_fname
 
 
-def run(job_iterator: Iterable[JobInfo], data_iterator: Callable, xy_function: Callable,
-        output_dir: str, qp_kwargs: Dict = None) -> pd.DataFrame:
+def run(job_iterator: Iterable[JobInfo], data_iterator: Callable,
+        xy_function: Callable, output_dir: str, use_fakeqp=False,
+        qp_kwargs: Dict = None) -> pd.DataFrame:
     """Creates a job for each item in job_iterator and collects the results."""
-    # os.chdir('.')
     sethandlers()
     if qp_kwargs is None:
         qp_kwargs = {}
+    qp_defaults = {'jobname': 'manager'}
 
-    with fakeqp(jobname='manager', **qp_kwargs) as q:
+    qprovider = qp if not use_fakeqp else fakeqp
+
+    with qprovider(**{**qp_defaults, **qp_kwargs}) as q:
         q.startpermanentrun()
 
         tkttores = []
         for job_info in job_iterator:
             tkttores.append(q.method(_run_per_job, (job_info, data_iterator, xy_function,
-                                                    output_dir),
-                                     _job_name=job_info.name))
+                                                    output_dir)))
 
         fnames = []
         for r in tkttores:

--- a/MWFTP/test_manager.py
+++ b/MWFTP/test_manager.py
@@ -19,7 +19,7 @@ class TestManager(unittest.TestCase):
             return {'key': k, 'sum': sum(x) + sum(y)}
 
         tmpdir = tempfile.mkdtemp()
-        result = run(infos, data_iterator_gen, xy_func, tmpdir)
+        result = run(infos, data_iterator_gen, xy_func, tmpdir, use_fakeqp=True)
         expected = pd.DataFrame({'key': ['key1', 'key2'], 'sum': [20, 0]})
 
         pd.testing.assert_frame_equal(result, expected)


### PR DESCRIPTION
One logic that I changed is with job name: it now uses the 'manager' string (or from qp_kwargs) rather than info.jobname. Let me know if that makes sense to you.